### PR TITLE
cmake use prefix libusrsctp and pkg_config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,6 @@ install:
 # Set environment vars & enable core dumps
 before_script:
   - export BUILD_PATH=$HOME/build/rawrtc/rawrtc/build
-  - export PKG_CONFIG_PATH=${BUILD_PATH}/prefix/lib/pkgconfig:${PKG_CONFIG_PATH}
   - export LD_LIBRARY_PATH=${BUILD_PATH}/prefix/lib:${LD_LIBRARY_PATH}
   - export PATH=${BUILD_PATH}/prefix/bin:${PATH}
   - ulimit -c unlimited -S

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ set(PROJECT_DESCRIPTION
 set(PROJECT_URL
         "https://github.com/rawrtc/rawrtc")
 
+# Use prefix pkgconfig
+set(ENV{PKG_CONFIG_PATH} "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig/:$ENV{PKG_CONFIG_PATH}")
+
 # Dependency versions
 set(OPENSSL_VERSION "openssl >= 1.0.2")
 set(LIB_RE_VERSION "libre >= 0.5.2")
@@ -67,8 +70,8 @@ list(APPEND rawrtc_DEP_LIBRARIES ${LIB_REW_STATIC_LIBRARIES})
 
 # Dependency: usrsctp
 # TODO: Use the pkg-config file of usrsctp once it has been added
-find_library(LIB_USRSCTP_LIBRARIES NAMES usrsctp.a libusrsctp.a)
-find_path(LIB_USRSCTP_INCLUDE_DIRS usrsctp.h)
+find_library(LIB_USRSCTP_LIBRARIES NAMES usrsctp.a libusrsctp.a HINTS ${CMAKE_INSTALL_PREFIX}/lib )
+find_path(LIB_USRSCTP_INCLUDE_DIRS usrsctp.h HINTS ${CMAKE_INSTALL_PREFIX}/include )
 get_filename_component(LIB_USRSCTP_LIBRARY_DIRS ${LIB_USRSCTP_LIBRARIES} DIRECTORY)
 include_directories(${LIB_USRSCTP_INCLUDE_DIRS})
 link_directories(${LIB_USRSCTP_LIBRARY_DIRS})


### PR DESCRIPTION
Fixes issue https://github.com/rawrtc/rawrtc/issues/72

I've also included the fix I needed to add to use the prefix `pkg_config`. I couldn't compile it without this.