### PR TITLE
Fix compilation errors on Windows

### DIFF
--- a/src/include/rawrtc.h
+++ b/src/include/rawrtc.h
@@ -4,7 +4,9 @@
 
 #include <stdlib.h> // TODO: Why?
 #include <stdbool.h> // bool
+#ifndef _WIN32
 #include <netinet/in.h> // IPPROTO_UDP, IPPROTO_TCP, ...
+#endif
 #include <openssl/evp.h> // EVP_PKEY
 
 //#define ZF_LOG_LIBRARY_PREFIX rawrtc_

--- a/src/librawrtc/certificate.c
+++ b/src/librawrtc/certificate.c
@@ -1,15 +1,4 @@
-#include <openssl/err.h>
-#include <openssl/rsa.h>
-#include <openssl/bn.h>
-#include <openssl/objects.h>
-#include <openssl/ec.h>
-#include <openssl/evp.h>
-#include <openssl/x509.h>
-#include <openssl/asn1.h>
-#include <openssl/asn1t.h>
-#include <openssl/crypto.h>
-#include <openssl/bio.h>
-#include <openssl/pem.h>
+
 #include <string.h>
 #include <limits.h>
 #include <rawrtc.h>
@@ -19,6 +8,18 @@
 #define DEBUG_MODULE "certificate"
 //#define RAWRTC_DEBUG_MODULE_LEVEL 7 // Note: Uncomment this to debug this module only
 #include "debug.h"
+#include <openssl/err.h>
+#include <openssl/rsa.h>
+#include <openssl/bn.h>
+#include <openssl/objects.h>
+#include <openssl/ec.h>
+#include <openssl/evp.h>
+#include <openssl/asn1.h>
+#include <openssl/asn1t.h>
+#include <openssl/crypto.h>
+#include <openssl/bio.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
 
 /*
  * Print and flush the OpenSSL error queue.

--- a/src/librawrtc/ice_candidate.c
+++ b/src/librawrtc/ice_candidate.c
@@ -1,4 +1,3 @@
-#include <netinet/in.h> // IPPROTO_UDP, IPPROTO_TCP
 #include <rawrtc.h>
 #include "ice_candidate.h"
 #include "utils.h"

--- a/src/librawrtc/ice_gatherer.c
+++ b/src/librawrtc/ice_gatherer.c
@@ -1457,6 +1457,11 @@ static bool interface_handler(
         return false; // Continue gathering
     }
 
+    // Ignore 0.0.0.0
+    if(sa_af(address) == AF_INET && address->u.in.sin_addr.s_addr == 0) {
+        return false;
+    }
+
     // Skip IPv4, IPv6?
     // TODO: Get config from struct
     af = sa_af(address);

--- a/src/librawrtc/ice_gatherer.c
+++ b/src/librawrtc/ice_gatherer.c
@@ -1,5 +1,7 @@
+#ifndef _WIN32
 #include <sys/socket.h> // AF_INET, AF_INET6
 #include <netinet/in.h> // IPPROTO_UDP, IPPROTO_TCP
+#endif
 #include <string.h> // memcpy
 #include <rawrtc.h>
 #include "ice_gatherer.h"
@@ -12,6 +14,7 @@
 //#define RAWRTC_DEBUG_MODULE_LEVEL 7 // Note: Uncomment this to debug this module only
 #define RAWRTC_DEBUG_ICE_GATHERER 0 // TODO: Remove
 #include "debug.h"
+
 
 /*
  * ICE server URL-related regular expressions.
@@ -1434,14 +1437,14 @@ static enum rawrtc_code add_candidate(
  * TODO: https://tools.ietf.org/html/draft-ietf-rtcweb-ip-handling-01
   */
 static bool interface_handler(
-        char const* interface, // not checked
+        char const* iface, // not checked
         struct sa const* address, // not checked
         void* arg // not checked
 ) {
     int af;
     struct rawrtc_ice_gatherer* const gatherer = arg;
     enum rawrtc_code error = RAWRTC_CODE_SUCCESS;
-    (void) interface;
+    (void) iface;
 
     // Check state
     if (gatherer->state == RAWRTC_ICE_GATHERER_CLOSED) {

--- a/src/librawrtc/sctp_transport.c
+++ b/src/librawrtc/sctp_transport.c
@@ -1,8 +1,11 @@
 #include <stdio.h> // fopen
 #include <string.h> // memcpy, strlen
 #include <errno.h> // errno
+#ifndef _WIN32
 #include <sys/socket.h> // AF_INET, SOCK_STREAM, linger
 #include <netinet/in.h> // IPPROTO_UDP, IPPROTO_TCP, htons
+#endif
+#include <pthread.h>
 #if (RAWRTC_DEBUG_LEVEL >= 7)
     #define SCTP_DEBUG
 #endif

--- a/src/librawrtc/utils.c
+++ b/src/librawrtc/utils.c
@@ -1,6 +1,8 @@
 #include <stdio.h> // sprintf
 #include <string.h> // strlen
+#ifndef _WIN32
 #include <netinet/in.h> // IPPROTO_UDP, IPPROTO_TCP
+#endif
 #include <stdarg.h>
 #include <openssl/evp.h> // EVP_MD, evp_*
 #include <rawrtc.h>


### PR DESCRIPTION
Now it is somewhat compilable with MinGW on Windows.
- Some headers were missing on windows
- X509_NAME was redefined somewhere, had to change include order
- "interface" was redefined
- 0.0.0.0 is not a valid address, should be ignored
