### PR TITLE
Update make-dependencies.sh to work with clang & Xcode 10.1

### DIFF
--- a/make-dependencies.sh
+++ b/make-dependencies.sh
@@ -64,7 +64,7 @@ fi
 # Extra cflags when using clang
 clang_extra_cflags=""
 if [ "${CC}" = "clang" ]; then
-    clang_extra_cflags=" -Wno-error=unused-command-line-argument"
+    clang_extra_cflags=" -Wno-error=unused-command-line-argument -Wno-pedantic -Wno-strict-prototypes"
 fi
 
 # Check for DTLS 1.2 suppport in openssl


### PR DESCRIPTION
Hi, I get errors with the version of clang that comes with Xcode 10.1 on macOS 10.14. Due to `-Werror`, these fail the build. Adding some flags fixes it.

```
$ clang -v
Apple LLVM version 10.0.0 (clang-1000.11.45.5)
Target: x86_64-apple-darwin18.0.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

I needed to do some other things to get this building, namely

* install pkg-config
* install zlib
* set `SYSROOT` for re

```
SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr
```

After that, I was able to build successfully.