### PR TITLE
Fix BoringSSL compatibility

### DIFF
--- a/src/certificate/certificate.c
+++ b/src/certificate/certificate.c
@@ -84,7 +84,7 @@ static enum rawrtc_code generate_key_rsa(
     }
 
     // Allocate BIGNUM
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(OPENSSL_IS_BORINGSSL)
     bn = BN_secure_new();
 #else
     bn = BN_new();
@@ -642,7 +642,7 @@ enum rawrtc_code rawrtc_certificate_get_pem(
     error = RAWRTC_CODE_UNKNOWN_ERROR;
 
     // Create bio structure
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(OPENSSL_IS_BORINGSSL)
     bio = BIO_new(BIO_s_secmem());
 #else
     bio = BIO_new(BIO_s_mem());

--- a/src/diffie_hellman_parameters/parameters.c
+++ b/src/diffie_hellman_parameters/parameters.c
@@ -23,7 +23,7 @@ static enum rawrtc_code set_dh_parameters(
     int codes;
 
     // Check that the parameters are "likely enough to be valid"
-#if OPENSSL_VERSION_NUMBER < 0x1010000fL
+#if OPENSSL_VERSION_NUMBER < 0x1010000fL || defined(OPENSSL_IS_BORINGSSL)
     if (!DH_check(dh, &codes)) {
         return RAWRTC_CODE_INVALID_ARGUMENT;
     }


### PR DESCRIPTION
Supersedes: https://github.com/rawrtc/rawrtc/pull/137

Please note that BoringSSL is not officially supported by re and this project but I will accept pull requests if they aren't *invasive*.