### PR TITLE
Calculate ICE candidate priority

### DIFF
--- a/src/ice_candidate/candidate.h
+++ b/src/ice_candidate/candidate.h
@@ -40,6 +40,7 @@ struct rawrtc_ice_candidate {
 
 // Note: Cannot be public until it uses fixed size types in signature (stdint)
 uint32_t rawrtc_ice_candidate_calculate_priority(
+    uint32_t const n_candidates,
     enum ice_cand_type const candidate_type,
     int const protocol,
     int const address_family,

--- a/src/ice_gatherer/gatherer.c
+++ b/src/ice_gatherer/gatherer.c
@@ -468,7 +468,8 @@ static void reflexive_candidate_handler(
     // Add server reflexive candidate
     // TODO: Using the candidate's protocol, TCP type and component id correct?
     priority = rawrtc_ice_candidate_calculate_priority(
-        ICE_CAND_TYPE_SRFLX, re_candidate->attr.proto, sa_af(address), re_candidate->attr.tcptype);
+        list_count(trice_lcandl(gatherer->ice)), ICE_CAND_TYPE_SRFLX, re_candidate->attr.proto,
+        sa_af(address), re_candidate->attr.tcptype);
     err = trice_lcand_add(
         &srflx_candidate, gatherer->ice, re_candidate->attr.compid, re_candidate->attr.proto,
         priority, address, &re_candidate->attr.addr, ICE_CAND_TYPE_SRFLX, &re_candidate->attr.addr,
@@ -693,7 +694,8 @@ static enum rawrtc_code add_candidate(
 
     // Add host candidate
     priority = rawrtc_ice_candidate_calculate_priority(
-        ICE_CAND_TYPE_HOST, ipproto, sa_af(address), tcp_type);
+        list_count(trice_lcandl(gatherer->ice)), ICE_CAND_TYPE_HOST, ipproto, sa_af(address),
+        tcp_type);
     // TODO: Set component id properly
     err = trice_lcand_add(
         &re_candidate, gatherer->ice, 1, ipproto, priority, address, NULL, ICE_CAND_TYPE_HOST, NULL,

--- a/tools/ice-gatherer.c
+++ b/tools/ice-gatherer.c
@@ -51,8 +51,8 @@ int main(int argc, char* argv[argc + 1]) {
         gather_options, stun_google_com_ip_urls, ARRAY_SIZE(stun_google_com_ip_urls), NULL, NULL,
         RAWRTC_ICE_CREDENTIAL_TYPE_NONE));
     EOE(rawrtc_ice_gather_options_add_server(
-            gather_options, unreachable_urls, ARRAY_SIZE(unreachable_urls), NULL, NULL,
-            RAWRTC_ICE_CREDENTIAL_TYPE_NONE));
+        gather_options, unreachable_urls, ARRAY_SIZE(unreachable_urls), NULL, NULL,
+        RAWRTC_ICE_CREDENTIAL_TYPE_NONE));
 
     // Setup client
     client.name = "A";


### PR DESCRIPTION
Preference order in priority calculation:

1. UDP over TCP, then
2. IPv6 over IPv4, then
3. Older candidates over newer candidates.