### PR TITLE
Expose options for limiting port range in ICE candidates

### DIFF
--- a/include/rawrtc/ice_gather_options.h
+++ b/include/rawrtc/ice_gather_options.h
@@ -34,6 +34,12 @@ enum rawrtc_code rawrtc_ice_gather_options_create(
     enum rawrtc_ice_gather_policy const gather_policy);
 
 /*
+ * Force ICE candidates to be generated within a specific range of UDP ports.
+ */
+enum rawrtc_code rawrtc_ice_gather_options_set_udp_port_range(
+    struct rawrtc_ice_gather_options* const options, uint16_t min_udp_port, uint16_t max_udp_port);
+
+/*
  * Add an ICE server to the gather options.
  */
 enum rawrtc_code rawrtc_ice_gather_options_add_server(

--- a/include/rawrtc/peer_connection_configuration.h
+++ b/include/rawrtc/peer_connection_configuration.h
@@ -94,3 +94,11 @@ enum rawrtc_code rawrtc_peer_connection_configuration_set_sctp_mtu(
  */
 enum rawrtc_code rawrtc_peer_connection_configuration_set_sctp_mtu_discovery(
     struct rawrtc_peer_connection_configuration* configuration, bool on);
+
+/*
+ * Force local ICE candidate generation to use the specified local UDP ports.
+ */
+enum rawrtc_code rawrtc_peer_connection_configuration_set_ice_udp_port_range(
+    struct rawrtc_peer_connection_configuration* configuration,
+    uint16_t min_port,
+    uint16_t max_port);

--- a/src/ice_gather_options/options.c
+++ b/src/ice_gather_options/options.c
@@ -37,9 +37,27 @@ enum rawrtc_code rawrtc_ice_gather_options_create(
     // Set fields/reference
     options->gather_policy = gather_policy;
     list_init(&options->ice_servers);
+    options->udp_port_range.min = 0;
+    options->udp_port_range.max = 0;
 
     // Set pointer and return
     *optionsp = options;
+    return RAWRTC_CODE_SUCCESS;
+}
+
+enum rawrtc_code rawrtc_ice_gather_options_set_udp_port_range(
+    struct rawrtc_ice_gather_options* const options, uint16_t min_udp_port, uint16_t max_udp_port) {
+    if (!options) {
+        return RAWRTC_CODE_INVALID_ARGUMENT;
+    }
+
+    if (max_udp_port < min_udp_port) {
+        return RAWRTC_CODE_INVALID_ARGUMENT;
+    }
+
+    options->udp_port_range.min = min_udp_port;
+    options->udp_port_range.max = max_udp_port;
+
     return RAWRTC_CODE_SUCCESS;
 }
 

--- a/src/ice_gather_options/options.h
+++ b/src/ice_gather_options/options.h
@@ -7,6 +7,10 @@
 struct rawrtc_ice_gather_options {
     enum rawrtc_ice_gather_policy gather_policy;
     struct list ice_servers;
+    struct {
+        uint16_t min;
+        uint16_t max;
+    } udp_port_range;
 };
 
 enum rawrtc_code rawrtc_ice_gather_options_add_server_internal(

--- a/src/ice_gatherer/gatherer.c
+++ b/src/ice_gatherer/gatherer.c
@@ -106,6 +106,13 @@ enum rawrtc_code rawrtc_ice_gatherer_create(
         goto out;
     }
 
+    err = trice_set_port_range(
+        gatherer->ice, options->udp_port_range.min, options->udp_port_range.max);
+    if (err) {
+        DEBUG_WARNING("Unable to set ICE port range, reason: %m\n", err);
+        goto out;
+    }
+
     // Get local DNS servers
     err = dns_srv_get(NULL, 0, dns_servers, &n_dns_servers);
     if (err) {

--- a/src/peer_connection/connection.c
+++ b/src/peer_connection/connection.c
@@ -520,6 +520,13 @@ static enum rawrtc_code get_ice_gatherer(
         return error;
     }
 
+    error = rawrtc_ice_gather_options_set_udp_port_range(
+        options, connection->configuration->ice_udp_port_range.min,
+        connection->configuration->ice_udp_port_range.max);
+    if (error) {
+        return error;
+    }
+
     // Add ICE servers to gather options
     for (le = list_head(&connection->configuration->ice_servers); le != NULL; le = le->next) {
         struct rawrtc_ice_server* const source_server = le->data;

--- a/src/peer_connection_configuration/configuration.c
+++ b/src/peer_connection_configuration/configuration.c
@@ -52,6 +52,8 @@ enum rawrtc_code rawrtc_peer_connection_configuration_create(
     configuration->sctp.congestion_ctrl_algorithm = RAWRTC_SCTP_TRANSPORT_CONGESTION_CTRL_RFC2581;
     configuration->sctp.mtu = 0;
     configuration->sctp.mtu_discovery = false;
+    configuration->ice_udp_port_range.min = 0;
+    configuration->ice_udp_port_range.max = 0;
 
     // Set pointer and return
     *configurationp = configuration;
@@ -256,5 +258,20 @@ enum rawrtc_code rawrtc_peer_connection_configuration_set_sctp_mtu_discovery(
 
     // Set
     configuration->sctp.mtu_discovery = on;
+    return RAWRTC_CODE_SUCCESS;
+}
+
+enum rawrtc_code rawrtc_peer_connection_configuration_set_ice_udp_port_range(
+    struct rawrtc_peer_connection_configuration* configuration,
+    uint16_t min_port,
+    uint16_t max_port) {
+    if (!configuration) {
+        return RAWRTC_CODE_INVALID_ARGUMENT;
+    }
+    if (max_port < min_port) {
+        return RAWRTC_CODE_INVALID_ARGUMENT;
+    }
+    configuration->ice_udp_port_range.min = min_port;
+    configuration->ice_udp_port_range.max = max_port;
     return RAWRTC_CODE_SUCCESS;
 }

--- a/src/peer_connection_configuration/configuration.h
+++ b/src/peer_connection_configuration/configuration.h
@@ -17,6 +17,10 @@ struct rawrtc_peer_connection_configuration {
         uint32_t mtu;
         bool mtu_discovery;
     } sctp;
+    struct {
+        uint16_t min;
+        uint16_t max;
+    } ice_udp_port_range;
 };
 
 enum rawrtc_code rawrtc_peer_connection_configuration_add_ice_server_internal(

--- a/tools/ice-gatherer.c
+++ b/tools/ice-gatherer.c
@@ -26,10 +26,10 @@ int main(int argc, char* argv[argc + 1]) {
     struct rawrtc_ice_gather_options* gather_options;
     struct rawrtc_ice_gatherer* gatherer;
     char* const turn_zwuenf_org_urls[] = {"stun:turn.zwuenf.org"};
-    char* const stun_google_com_ip_urls[] = {"stun:[2a00:1450:400c:c08::7f]:19302",
-                                             "stun:74.125.140.127:19302"};
-    char* const unreachable_urls[] = {"stun:example.com:12345",
-                                      "stun:lets.assume.no-one-will-ever-register-this"};
+    char* const stun_google_com_ip_urls[] = {
+        "stun:[2a00:1450:400c:c08::7f]:19302", "stun:74.125.140.127:19302"};
+    char* const unreachable_urls[] = {
+        "stun:example.com:12345", "stun:lets.assume.no-one-will-ever-register-this"};
     struct client client = {0};
     (void) argv;
 


### PR DESCRIPTION
In some environments there are firewalls that filter out traffic
ooutside of limited port ranges. Expose the options that allow us to
select ICE (UDP) candidates within just a limited range of ports.

Note: I am not terribly familiar with the normal conventions for how these APIs are meant to work, so I may not currently be following quite the correct conventions. Happy to update that.