### PR TITLE
Mark some input char*'s as const

### DIFF
--- a/include/rawrtc/ice_gather_options.h
+++ b/include/rawrtc/ice_gather_options.h
@@ -44,10 +44,10 @@ enum rawrtc_code rawrtc_ice_gather_options_set_udp_port_range(
  */
 enum rawrtc_code rawrtc_ice_gather_options_add_server(
     struct rawrtc_ice_gather_options* const options,
-    char* const* const urls,  // copied
+    char const* const* const urls,  // copied
     size_t const n_urls,
-    char* const username,  // nullable, copied
-    char* const credential,  // nullable, copied
+    char const* const username,  // nullable, copied
+    char const* const credential,  // nullable, copied
     enum rawrtc_ice_credential_type const credential_type);
 
 /*

--- a/include/rawrtc/peer_connection_configuration.h
+++ b/include/rawrtc/peer_connection_configuration.h
@@ -27,10 +27,10 @@ enum rawrtc_code rawrtc_peer_connection_configuration_create(
  */
 enum rawrtc_code rawrtc_peer_connection_configuration_add_ice_server(
     struct rawrtc_peer_connection_configuration* const configuration,
-    char* const* const urls,  // copied
+    char const* const* const urls,  // copied
     size_t const n_urls,
-    char* const username,  // nullable, copied
-    char* const credential,  // nullable, copied
+    char const* const username,  // nullable, copied
+    char const* const credential,  // nullable, copied
     enum rawrtc_ice_credential_type const credential_type);
 
 /*

--- a/include/rawrtc/peer_connection_ice_candidate.h
+++ b/include/rawrtc/peer_connection_ice_candidate.h
@@ -20,8 +20,8 @@ struct rawrtc_peer_connection_ice_candidate;
  */
 enum rawrtc_code rawrtc_peer_connection_ice_candidate_create(
     struct rawrtc_peer_connection_ice_candidate** const candidatep,  // de-referenced
-    char* const sdp,
-    char* const mid,  // nullable, copied
+    char const* const sdp,
+    char const* const mid,  // nullable, copied
     uint8_t const* const media_line_index,  // nullable, copied
     char* const username_fragment  // nullable, copied
 );

--- a/src/ice_gather_options/options.c
+++ b/src/ice_gather_options/options.c
@@ -81,10 +81,10 @@ enum rawrtc_code rawrtc_ice_gather_options_add_server_internal(
  */
 enum rawrtc_code rawrtc_ice_gather_options_add_server(
     struct rawrtc_ice_gather_options* const options,
-    char* const* const urls,  // copied
+    char const* const* const urls,  // copied
     size_t const n_urls,
-    char* const username,  // nullable, copied
-    char* const credential,  // nullable, copied
+    char const* const username,  // nullable, copied
+    char const* const credential,  // nullable, copied
     enum rawrtc_ice_credential_type const credential_type) {
     struct rawrtc_ice_server* server;
     enum rawrtc_code error;

--- a/src/ice_server/server.c
+++ b/src/ice_server/server.c
@@ -334,10 +334,10 @@ static void rawrtc_ice_server_destroy(void* arg) {
  */
 enum rawrtc_code rawrtc_ice_server_create(
     struct rawrtc_ice_server** const serverp,  // de-referenced
-    char* const* const urls,  // copied
+    char const* const* const urls,  // copied
     size_t const n_urls,
-    char* const username,  // nullable, copied
-    char* const credential,  // nullable, copied
+    char const* const username,  // nullable, copied
+    char const* const credential,  // nullable, copied
     enum rawrtc_ice_credential_type const credential_type) {
     struct rawrtc_ice_server* server;
     enum rawrtc_code error = RAWRTC_CODE_SUCCESS;

--- a/src/ice_server/server.h
+++ b/src/ice_server/server.h
@@ -35,10 +35,10 @@ struct rawrtc_ice_server_url {
 
 enum rawrtc_code rawrtc_ice_server_create(
     struct rawrtc_ice_server** const serverp,  // de-referenced
-    char* const* const urls,  // copied
+    char const* const* const urls,  // copied
     size_t const n_urls,
-    char* const username,  // nullable, copied
-    char* const credential,  // nullable, copied
+    char const* const username,  // nullable, copied
+    char const* const credential,  // nullable, copied
     enum rawrtc_ice_credential_type const credential_type);
 
 enum rawrtc_code rawrtc_ice_server_copy(

--- a/src/peer_connection_configuration/configuration.c
+++ b/src/peer_connection_configuration/configuration.c
@@ -81,10 +81,10 @@ enum rawrtc_code rawrtc_peer_connection_configuration_add_ice_server_internal(
  */
 enum rawrtc_code rawrtc_peer_connection_configuration_add_ice_server(
     struct rawrtc_peer_connection_configuration* const configuration,
-    char* const* const urls,  // copied
+    char const* const* const urls,  // copied
     size_t const n_urls,
-    char* const username,  // nullable, copied
-    char* const credential,  // nullable, copied
+    char const* const username,  // nullable, copied
+    char const* const credential,  // nullable, copied
     enum rawrtc_ice_credential_type const credential_type) {
     struct rawrtc_ice_server* server;
     enum rawrtc_code error;

--- a/src/peer_connection_ice_candidate/candidate.c
+++ b/src/peer_connection_ice_candidate/candidate.c
@@ -64,7 +64,7 @@ enum rawrtc_code rawrtc_peer_connection_ice_candidate_from_ortc_candidate(
 enum rawrtc_code rawrtc_peer_connection_ice_candidate_create_internal(
     struct rawrtc_peer_connection_ice_candidate** const candidatep,  // de-referenced
     struct pl* const sdp,
-    char* const mid,  // nullable, referenced
+    char const* const mid,  // nullable, referenced
     uint8_t const* const media_line_index,  // nullable, copied
     char* const username_fragment  // nullable, referenced
 ) {
@@ -205,8 +205,8 @@ out:
  */
 enum rawrtc_code rawrtc_peer_connection_ice_candidate_create(
     struct rawrtc_peer_connection_ice_candidate** const candidatep,  // de-referenced
-    char* const sdp,
-    char* const mid,  // nullable, copied
+    char const* const sdp,
+    char const* const mid,  // nullable, copied
     uint8_t const* const media_line_index,  // nullable, copied
     char* const username_fragment  // nullable, copied
 ) {

--- a/src/peer_connection_ice_candidate/candidate.h
+++ b/src/peer_connection_ice_candidate/candidate.h
@@ -27,6 +27,6 @@ enum rawrtc_code rawrtc_peer_connection_ice_candidate_from_ortc_candidate(
 enum rawrtc_code rawrtc_peer_connection_ice_candidate_create_internal(
     struct rawrtc_peer_connection_ice_candidate** const candidatep,  // de-referenced
     struct pl* const sdp,
-    char* const mid,  // nullable
+    char const* const mid,  // nullable
     uint8_t const* const media_line_index,  // nullable
     char* const username_fragment);


### PR DESCRIPTION
They aren't actually being modified and having them non-const
complicates the interface.